### PR TITLE
Adding dist trusty as HHVM is not supported without it and build will…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+dist: trusty
 php:
   - 5.5
   - 5.4


### PR DESCRIPTION
After fixing the tests and running Travis, the build fails on HHVM. Since HHVM is not supported anymore on the default dist, the configuration dist: trusty is needed